### PR TITLE
feat(utils/values): change prepare value to compile objects and not stringify ? value

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = tab
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
   "homepage": "https://github.com/jeanpsv/node-cassandra-querybuilder#readme",
   "devDependencies": {
     "mocha": "^2.4.5"
+  },
+  "dependencies": {
+    "stringify-object": "^3.2.0"
   }
 }

--- a/test/statements/insert.js
+++ b/test/statements/insert.js
@@ -36,17 +36,11 @@ describe('Insert', function() {
 			var table = 'table';
 			var f = new From();
 			var columns = ['col1', 'col2'];
-			var prepared_values = ['\'' + '?' + '\'', 10];
 			var values = ['?', 10];
 			f.from(database, table);
 			var i = new Insert();
-			var to_string = [];
-			to_string.push('INSERT INTO');
-			to_string.push(f.toString(false));
-			to_string.push('(' + columns.join() + ')');
-			to_string.push('VALUES');
-			to_string.push('(' + prepared_values.join() + ');');
-			assert.equal(i.from(database, table).columns(columns).values(values).toString(), to_string.join(' '));
+			var query = 'INSERT INTO database.table (col1,col2) VALUES (?,10);'
+			assert.equal(i.from(database, table).columns(columns).values(values).toString(), query);
 		});
 	});
 });

--- a/test/utils/values.js
+++ b/test/utils/values.js
@@ -9,10 +9,17 @@ describe('Values', function() {
 		var string = 'string';
 		var integer = 5;
 		var uuid = new UUID('652f2270-fac4-11e5-bcc3-452e2b89ab68');
+		var obj = {
+			key: 'value',
+			subObject: {
+				subKey: 'subValue'
+			}
+		};
 
 		assert.equal(Values.prepare(string), '\'' + string + '\'');
 		assert.equal(Values.prepare(integer), integer);
 		assert.equal(Values.prepare(uuid), uuid);
+		assert.equal(Values.prepare(obj), '{\n\tkey: \'value\',\n\tsubObject: {\n\t\tsubKey: \'subValue\'\n\t}\n}')
 	})
 	describe('#constructor', function() {
 		it('should create an instance of Values', function() {

--- a/utils/values.js
+++ b/utils/values.js
@@ -1,4 +1,6 @@
 var Equal = require('../operators/eq');
+var stringifyObject = require('stringify-object');
+var UUID = require('./uuid')
 /**
  * Values constructor
  */
@@ -13,6 +15,34 @@ function Values() {
  * @return {string}       prepared value
  */
 Values.prepare = function(value) {
+	switch(typeof value) {
+		case 'string':
+			if (value === '?') {
+				return value;
+			}
+
+			var regExp = new RegExp(/\\n/, 'g');
+
+			if (regExp.test(value)) {
+				return '\"' + value + '\"';
+			}
+
+			return '\'' + value + '\'';
+
+		case 'object':
+			if (value instanceof UUID) {
+				return value.toString()
+			}
+
+			return stringifyObject(value, {
+				indent: '',
+				singleQuotes: true
+			});
+
+		default:
+			return value.toString();
+	}
+
 	return (typeof value === 'string') ? '\'' + value + '\'' : value.toString();
 };
 


### PR DESCRIPTION
Hi!

If you are aware for PR I just made some improvements about values: 
- now you can pass object into values
- now `?` is not quoted as a string, so cassandra client can interpolate arguments
- finally I just add .editorconfig file to match your editor style

Have a nice day